### PR TITLE
Implement supporter password reset request workflow

### DIFF
--- a/Alvand/templates/userprofile.html
+++ b/Alvand/templates/userprofile.html
@@ -1180,47 +1180,56 @@ label.required:after,
             </div>
         {% endif %}
         
-        <form method="post" id="form" enctype="multipart/form-data" novalidate>
-            {% csrf_token %}
-            
-
-            <!-- Password Reset Requests Section -->
-            {% if password_reset_requests %}
-            <div class="form-section">
-                <h2 class="text-lg font-semibold mb-4">درخواست‌های بازنشانی رمز عبور</h2>
-                <div class="alert alert-warning">
-                    <i class="fa-solid fa-triangle-exclamation"></i> 
-                    <strong>توجه:</strong> برای بازنشانی رمز عبور کاربر، نام کاربری را در قسمت ویرایش وارد کنید و سپس دکمه "بازنشانی رمز عبور" را بزنید.
-                </div>
+        {% if password_reset_requests %}
+        <div class="form-section password-reset-requests">
+            <h2 class="text-lg font-semibold mb-4">درخواست‌های بازنشانی رمز عبور</h2>
+            <div class="alert alert-warning">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                <strong>توجه:</strong> با تأیید هر درخواست، رمز عبور کاربر به مقدار پیش‌فرض <strong>12345678</strong> تغییر خواهد کرد و کاربر ملزم به تغییر رمز پس از ورود است.
+            </div>
+            <div class="table-responsive" style="overflow-x: auto;">
                 <table style="width: 100%; margin-top: 1rem; border-collapse: collapse;">
                     <thead>
                         <tr>
                             <th style="padding: 0.75rem; text-align: right; border-bottom: 2px solid var(--border-color);">نام کاربری</th>
                             <th style="padding: 0.75rem; text-align: right; border-bottom: 2px solid var(--border-color);">نام و نام خانوادگی</th>
+                            <th style="padding: 0.75rem; text-align: right; border-bottom: 2px solid var(--border-color);">ایمیل</th>
                             <th style="padding: 0.75rem; text-align: right; border-bottom: 2px solid var(--border-color);">تاریخ درخواست</th>
                             <th style="padding: 0.75rem; text-align: right; border-bottom: 2px solid var(--border-color);">عملیات</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for request in password_reset_requests %}
+                        {% for reset_request in password_reset_requests %}
                         <tr>
-                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ request.user.username }}</td>
-                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ request.user.name }} {{ request.user.lastname }}</td>
-                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ request.created_at|date:"Y/m/d H:i" }}</td>
+                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ reset_request.user.username }}</td>
+                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ reset_request.user.name }} {{ reset_request.user.lastname }}</td>
+                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ reset_request.user.email|default:"—" }}</td>
+                            <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">{{ reset_request.created_at|date:"Y/m/d H:i" }}</td>
                             <td style="padding: 0.75rem; border-bottom: 1px solid var(--border-color);">
-                                <button type="button" class="select-user-btn" 
-                                        data-username="{{ request.user.username }}" 
-                                        style="background-color: #00BCD4; color: white; padding: 0.25rem 0.75rem; border-radius: 4px; border: none; cursor: pointer;">
-                                    انتخاب
-                                </button>
+                                <form method="post" action="{% url 'resolve_password_reset_request' reset_request.pk %}" style="display: inline-flex; gap: 0.5rem; align-items: center;">
+                                    {% csrf_token %}
+                                    <button type="submit" class="action-button password-reset resolve-reset-btn" data-username="{{ reset_request.user.username }}">
+                                        <i class="fa-solid fa-key"></i>
+                                        <span>بازنشانی به پیش‌فرض</span>
+                                    </button>
+                                </form>
                             </td>
+                        </tr>
+                        {% empty %}
+                        <tr>
+                            <td colspan="5" style="padding: 1rem; text-align: center; color: var(--light-text);">درخواستی برای بازنشانی رمز عبور ثبت نشده است.</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </div>
-            {% endif %}
-            
+        </div>
+        {% endif %}
+
+        <form method="post" id="form" enctype="multipart/form-data" novalidate>
+            {% csrf_token %}
+
+
             <!-- Enhanced User Profile Image Section -->
             <div class="profile-section">
                 <div class="profile-image-container">

--- a/Alvand/urls.py
+++ b/Alvand/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path('errors/', views.errorsPage.as_view(), name='errors'),
     path('errors/export/', views.error_export, name='error_export'),
     path('user/', views.UserForm.as_view(), name='user'),
+    path('user/password-reset/<int:pk>/resolve/', views.ResolvePasswordResetRequestView.as_view(), name='resolve_password_reset_request'),
     path('get-user-data/', views.get_user_data, name='get_user_data'),
     path('userprofile/', views.userprofile_view, name='userprofile'),
     path('change-password/', views.ChangePasswordView.as_view(), name='change_password'),

--- a/Alvand/views.py
+++ b/Alvand/views.py
@@ -1,7 +1,7 @@
 import datetime
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage, InvalidPage
 from django.http import HttpResponseRedirect, HttpResponse, JsonResponse
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.urls import reverse_lazy
 from .user_utils import getUserinfoByUsername, getTupleIndex
 from django.views.generic import TemplateView, View, FormView
@@ -2812,6 +2812,59 @@ class UserForm(FormView, View):
             return self.form_invalid(form)
 
 
+class ResolvePasswordResetRequestView(View):
+    """Handle supporter password reset requests from the management panel."""
+
+    default_password = "12345678"
+
+    def post(self, request, pk):
+        if not checkSession(request):
+            messages.error(request, messagesTypes.notlogin)
+            return redirect('login')
+
+        session_username = checkSession(request)
+        current_user = Users.objects.filter(username=session_username).first()
+
+        if not current_user or str(current_user.groupname).lower() not in ['supporter', 'superadmin']:
+            messages.error(request, messagesTypes.permissionsNotFound)
+            return redirect('user')
+
+        from .models import PasswordResetRequest
+
+        reset_request = get_object_or_404(
+            PasswordResetRequest.objects.select_related('user'),
+            pk=pk
+        )
+
+        if reset_request.resolved:
+            messages.warning(request, 'این درخواست بازنشانی قبلاً رسیدگی شده است.')
+            return redirect('user')
+
+        target_user = reset_request.user
+        target_user.password = make_password(self.default_password)
+        target_user.needs_password_change = True
+        target_user.save()
+
+        reset_request.resolved = True
+        reset_request.resolved_by = current_user
+        reset_request.resolved_at = timezone.now()
+        reset_request.save()
+
+        log(
+            request,
+            logErrCodes.userSettings,
+            f"رمز عبور کاربر {target_user.username} توسط {session_username} بازنشانی شد.",
+            session_username
+        )
+
+        messages.success(
+            request,
+            f"رمز عبور کاربر {target_user.username} با موفقیت به {self.default_password} تغییر یافت."
+        )
+
+        return redirect('user')
+
+
 def get_user_data(request):
     """AJAX endpoint to fetch user data for editing."""
     print(f"get_user_data called - Method: {request.method}")
@@ -3258,7 +3311,7 @@ def password_reset_request_count(request):
             groupname = user.groupname
     elif hasattr(request, 'user') and hasattr(request.user, 'groupname'):
         groupname = getattr(request.user, 'groupname', None)
-    if groupname and str(groupname).lower() in ['supporter', 'superadmin', 'admin']:
+    if groupname and str(groupname).lower() in ['supporter', 'superadmin']:
         count = PasswordResetRequest.objects.filter(resolved=False).count()
     return {'pending_password_reset_count': count}
 

--- a/static/js/user-profile-fix.js
+++ b/static/js/user-profile-fix.js
@@ -1059,151 +1059,20 @@ $(document).ready(function() {
     // Listen for checkbox changes
     $('input[type="checkbox"]').change(updateButtonText);
     
-    // Handle select user button for password reset requests
-    $('.select-user-btn').click(function() {
+    // Handle supporter password reset confirmations
+    $('.resolve-reset-btn').on('click', function(e) {
         const username = $(this).data('username');
-        
-        // Set the form to edit mode
-        $('#id_editOrAdd').val('edit');
-        $('#id_editOrAdd').trigger('change');
-        
-        // Fill in the username field
-        $('#id_username').val(username);
-        
-        // Trigger the username change to load user data
-        $('#id_username').trigger('change');
-        
-        // Scroll to the username field
-        $('html, body').animate({
-            scrollTop: $('#id_username').offset().top - 100
-        }, 500);
-        
-        // Highlight the fields
-        $('#id_username').css('border', '2px solid #00BCD4');
-        
-        // After a delay, automatically trigger password reset
-        setTimeout(function() {
-            $('#id_username').css('border', '');
-            
-            // Get the button for password reset
-            const resetButton = $('button[name="ChangePassword"]');
-            
-            // Add visual feedback
-            resetButton.css('background-color', '#00BCD4');
-            resetButton.css('transform', 'scale(1.05)');
-            
-            // Trigger the password reset
-            resetButton.trigger('click');
-            
-            // Show success message
-            $('<div class="alert alert-success" style="margin-top: 15px;">')
-                .html('<strong>موفق:</strong> رمز عبور کاربر ' + username + ' با موفقیت به 12345678 بازنشانی شد.')
-                .insertBefore($('.password-reset-requests'));
-        }, 1000);
+        const confirmationMessage = `آیا از بازنشانی رمز عبور کاربر ${username} به مقدار پیش‌فرض 12345678 اطمینان دارید؟`;
+
+        if (!confirm(confirmationMessage)) {
+            e.preventDefault();
+            return;
+        }
+
+        const button = $(this);
+        button.prop('disabled', true);
+        button.addClass('is-loading');
+        button.closest('form').submit();
     });
 
-    // Handle view user details button for password reset requests
-    $('.view-user-details-btn').click(function() {
-        const username = $(this).data('username');
-        const name = $(this).data('name');
-        const lastname = $(this).data('lastname');
-        const extension = $(this).data('extension');
-        const email = $(this).data('email');
-        const created = $(this).data('created');
-        const groupname = $(this).data('groupname');
-        
-        // Create HTML structure for modal with avatar
-        const modalHTML = `
-            <div style="display: flex; flex-direction: column; align-items: center; margin-bottom: 20px;">
-                <div class="user-avatar" style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; border: 3px solid #00BCD4; margin-bottom: 15px;">
-                    <img src="static/pic/avatar.jpg" alt="User Avatar" style="width: 100%; height: 100%; object-fit: cover;">
-                </div>
-                <div style="font-size: 1.2rem; font-weight: 600; margin-bottom: 5px;">${name} ${lastname}</div>
-                <div style="padding: 3px 10px; border-radius: 20px; background: #e3f2fd; color: #0d47a1; font-size: 0.85rem; margin-bottom: 15px;">${groupname}</div>
-            </div>
-            
-            <div class="user-info-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px;">
-                <div class="info-item">
-                    <div style="font-weight: 600; margin-bottom: 5px; color: #666;">شماره داخلی:</div>
-                    <div style="padding: 8px; background: #f5f5f5; border-radius: 4px;">${extension}</div>
-                </div>
-                <div class="info-item">
-                    <div style="font-weight: 600; margin-bottom: 5px; color: #666;">ایمیل:</div>
-                    <div style="padding: 8px; background: #f5f5f5; border-radius: 4px;">${email}</div>
-                </div>
-                <div class="info-item" style="grid-column: span 2;">
-                    <div style="font-weight: 600; margin-bottom: 5px; color: #666;">تاریخ درخواست بازنشانی:</div>
-                    <div style="padding: 8px; background: #f5f5f5; border-radius: 4px;">${created}</div>
-                </div>
-            </div>
-            
-            <div class="info-alert" style="padding: 10px 15px; background-color: #fff3cd; border: 1px solid #ffeaa7; color: #856404; border-radius: 4px; margin-bottom: 15px;">
-                <i class="fa-solid fa-triangle-exclamation"></i> 
-                <strong>توجه:</strong> با کلیک روی دکمه «بازنشانی رمز عبور»، رمز عبور کاربر به «12345678» تغییر خواهد کرد.
-            </div>
-        `;
-        
-        // Populate modal with user data
-        $('#modal-username').text(username);
-        $('#modal-body').html(modalHTML);
-        
-        // Store username in the reset button for later use
-        $('#reset-password-modal').data('username', username);
-        
-        // Show the modal
-        $('#user-details-modal').fadeIn(300);
-        $('#user-details-modal').removeClass('hidden');
-    });
-    
-    // Close modal when clicking the close button
-    $('#close-modal, #cancel-view-details').click(function() {
-        $('#user-details-modal').fadeOut(300);
-        setTimeout(function() {
-            $('#user-details-modal').addClass('hidden');
-        }, 300);
-    });
-    
-    // Handle password reset from modal
-    $('#reset-password-modal').click(function() {
-        const username = $(this).data('username');
-        
-        // Close the modal
-        $('#user-details-modal').fadeOut(300);
-        setTimeout(function() {
-            $('#user-details-modal').addClass('hidden');
-        
-            // Set the form to edit mode
-            $('#id_editOrAdd').val('edit');
-            $('#id_editOrAdd').trigger('change');
-            
-            // Fill in the username field
-            $('#id_username').val(username);
-            
-            // Trigger the username change to load user data
-            $('#id_username').trigger('change');
-            
-            // After a delay, automatically trigger password reset
-            setTimeout(function() {
-                // Get the button for password reset
-                const resetButton = $('button[name="ChangePassword"]');
-                
-                // Add visual feedback
-                resetButton.css('background-color', '#00BCD4');
-                resetButton.css('transform', 'scale(1.05)');
-                
-                // Trigger the password reset
-                resetButton.trigger('click');
-            }, 1000);
-        }, 300);
-    });
-    
-    // Close modal when clicking outside of it
-    $(window).click(function(e) {
-        if ($(e.target).is('#user-details-modal')) {
-            $('#user-details-modal').fadeOut(300);
-            setTimeout(function() {
-                $('#user-details-modal').addClass('hidden');
-            }, 300);
-        }
-    });
 }); })

--- a/staticfiles/js/user-profile-fix.js
+++ b/staticfiles/js/user-profile-fix.js
@@ -1059,151 +1059,20 @@ $(document).ready(function() {
     // Listen for checkbox changes
     $('input[type="checkbox"]').change(updateButtonText);
     
-    // Handle select user button for password reset requests
-    $('.select-user-btn').click(function() {
+    // Handle supporter password reset confirmations
+    $('.resolve-reset-btn').on('click', function(e) {
         const username = $(this).data('username');
-        
-        // Set the form to edit mode
-        $('#id_editOrAdd').val('edit');
-        $('#id_editOrAdd').trigger('change');
-        
-        // Fill in the username field
-        $('#id_username').val(username);
-        
-        // Trigger the username change to load user data
-        $('#id_username').trigger('change');
-        
-        // Scroll to the username field
-        $('html, body').animate({
-            scrollTop: $('#id_username').offset().top - 100
-        }, 500);
-        
-        // Highlight the fields
-        $('#id_username').css('border', '2px solid #00BCD4');
-        
-        // After a delay, automatically trigger password reset
-        setTimeout(function() {
-            $('#id_username').css('border', '');
-            
-            // Get the button for password reset
-            const resetButton = $('button[name="ChangePassword"]');
-            
-            // Add visual feedback
-            resetButton.css('background-color', '#00BCD4');
-            resetButton.css('transform', 'scale(1.05)');
-            
-            // Trigger the password reset
-            resetButton.trigger('click');
-            
-            // Show success message
-            $('<div class="alert alert-success" style="margin-top: 15px;">')
-                .html('<strong>موفق:</strong> رمز عبور کاربر ' + username + ' با موفقیت به 12345678 بازنشانی شد.')
-                .insertBefore($('.password-reset-requests'));
-        }, 1000);
+        const confirmationMessage = `آیا از بازنشانی رمز عبور کاربر ${username} به مقدار پیش‌فرض 12345678 اطمینان دارید؟`;
+
+        if (!confirm(confirmationMessage)) {
+            e.preventDefault();
+            return;
+        }
+
+        const button = $(this);
+        button.prop('disabled', true);
+        button.addClass('is-loading');
+        button.closest('form').submit();
     });
 
-    // Handle view user details button for password reset requests
-    $('.view-user-details-btn').click(function() {
-        const username = $(this).data('username');
-        const name = $(this).data('name');
-        const lastname = $(this).data('lastname');
-        const extension = $(this).data('extension');
-        const email = $(this).data('email');
-        const created = $(this).data('created');
-        const groupname = $(this).data('groupname');
-        
-        // Create HTML structure for modal with avatar
-        const modalHTML = `
-            <div style="display: flex; flex-direction: column; align-items: center; margin-bottom: 20px;">
-                <div class="user-avatar" style="width: 80px; height: 80px; border-radius: 50%; overflow: hidden; border: 3px solid #00BCD4; margin-bottom: 15px;">
-                    <img src="static/pic/avatar.jpg" alt="User Avatar" style="width: 100%; height: 100%; object-fit: cover;">
-                </div>
-                <div style="font-size: 1.2rem; font-weight: 600; margin-bottom: 5px;">${name} ${lastname}</div>
-                <div style="padding: 3px 10px; border-radius: 20px; background: #e3f2fd; color: #0d47a1; font-size: 0.85rem; margin-bottom: 15px;">${groupname}</div>
-            </div>
-            
-            <div class="user-info-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px;">
-                <div class="info-item">
-                    <div style="font-weight: 600; margin-bottom: 5px; color: #666;">شماره داخلی:</div>
-                    <div style="padding: 8px; background: #f5f5f5; border-radius: 4px;">${extension}</div>
-                </div>
-                <div class="info-item">
-                    <div style="font-weight: 600; margin-bottom: 5px; color: #666;">ایمیل:</div>
-                    <div style="padding: 8px; background: #f5f5f5; border-radius: 4px;">${email}</div>
-                </div>
-                <div class="info-item" style="grid-column: span 2;">
-                    <div style="font-weight: 600; margin-bottom: 5px; color: #666;">تاریخ درخواست بازنشانی:</div>
-                    <div style="padding: 8px; background: #f5f5f5; border-radius: 4px;">${created}</div>
-                </div>
-            </div>
-            
-            <div class="info-alert" style="padding: 10px 15px; background-color: #fff3cd; border: 1px solid #ffeaa7; color: #856404; border-radius: 4px; margin-bottom: 15px;">
-                <i class="fa-solid fa-triangle-exclamation"></i> 
-                <strong>توجه:</strong> با کلیک روی دکمه «بازنشانی رمز عبور»، رمز عبور کاربر به «12345678» تغییر خواهد کرد.
-            </div>
-        `;
-        
-        // Populate modal with user data
-        $('#modal-username').text(username);
-        $('#modal-body').html(modalHTML);
-        
-        // Store username in the reset button for later use
-        $('#reset-password-modal').data('username', username);
-        
-        // Show the modal
-        $('#user-details-modal').fadeIn(300);
-        $('#user-details-modal').removeClass('hidden');
-    });
-    
-    // Close modal when clicking the close button
-    $('#close-modal, #cancel-view-details').click(function() {
-        $('#user-details-modal').fadeOut(300);
-        setTimeout(function() {
-            $('#user-details-modal').addClass('hidden');
-        }, 300);
-    });
-    
-    // Handle password reset from modal
-    $('#reset-password-modal').click(function() {
-        const username = $(this).data('username');
-        
-        // Close the modal
-        $('#user-details-modal').fadeOut(300);
-        setTimeout(function() {
-            $('#user-details-modal').addClass('hidden');
-        
-            // Set the form to edit mode
-            $('#id_editOrAdd').val('edit');
-            $('#id_editOrAdd').trigger('change');
-            
-            // Fill in the username field
-            $('#id_username').val(username);
-            
-            // Trigger the username change to load user data
-            $('#id_username').trigger('change');
-            
-            // After a delay, automatically trigger password reset
-            setTimeout(function() {
-                // Get the button for password reset
-                const resetButton = $('button[name="ChangePassword"]');
-                
-                // Add visual feedback
-                resetButton.css('background-color', '#00BCD4');
-                resetButton.css('transform', 'scale(1.05)');
-                
-                // Trigger the password reset
-                resetButton.trigger('click');
-            }, 1000);
-        }, 300);
-    });
-    
-    // Close modal when clicking outside of it
-    $(window).click(function(e) {
-        if ($(e.target).is('#user-details-modal')) {
-            $('#user-details-modal').fadeOut(300);
-            setTimeout(function() {
-                $('#user-details-modal').addClass('hidden');
-            }, 300);
-        }
-    });
 }); })


### PR DESCRIPTION
## Summary
- add a dedicated view and route for supporters to resolve password reset requests with default credentials and auditing
- expose pending reset requests in the user management template with per-request actions
- add client-side confirmation handling for supporter-triggered resets

## Testing
- python manage.py check *(fails: Django is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dda5cc4c408328aa77d16b729dc97f